### PR TITLE
Implement and use fequal to fix false negatative tests.

### DIFF
--- a/tests/base.h
+++ b/tests/base.h
@@ -44,5 +44,13 @@ struct NoCopy {
 
 bool run_test_set(test_set& ts, std::ostream& os);
 
+/**
+ * Test if two floats are equal to the 10th digit.
+ * Some tests involving floating point calculations may fail due to subtle 
+ * differences between the target answer and the calculation if a regular
+ * equality is used.
+ */
+bool fequal(float x, float y);
+
 #endif
 

--- a/tests/functional_tests.cpp
+++ b/tests/functional_tests.cpp
@@ -54,9 +54,9 @@ test_set functional_tests{
 
 				auto f = [](int x){ return float(x)/3.f; };
 
-				return (f % unary)(2) == 4.f/3.f
-					&& (f % binary)(2,2) == 4.f/3.f
-					&& (unary % binary)(2,2) == 8;
+				return fequal((f % unary)(2), 4.f/3.f)
+					&& fequal((f % binary)(2,2), 4.f/3.f)
+					&& fequal((unary % binary)(2,2), 8);
 				;
 			})
 		),
@@ -125,8 +125,8 @@ test_set functional_tests{
 
 				auto f = [](int x){ return float(x)/3.f; };
 
-				return (f % unary)(2) == 4.f/3.f
-					&& (f % binary)(2,2) == 4.f/3.f;
+				return fequal((f % unary)(2), 4.f/3.f)
+					&& fequal((f % binary)(2,2), 4.f/3.f);
 				;
 			})
 		),

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -72,6 +72,11 @@ bool run_test_set(test_set& ts, std::ostream& os) {
 	return nfail == 0;
 }
 
+bool fequal(float x, float y) {
+	constexpr float PRECISION = 10000000000;
+	return int(x*PRECISION) == int(y*PRECISION);
+}
+
 int main(int, char**) {
 
 	bool flawless = true;

--- a/tests/map_tests.cpp
+++ b/tests/map_tests.cpp
@@ -97,7 +97,7 @@ test_set map_tests{
 				auto f = [](float x, float y){ return x/y; };
 
 
-				return foldr(f, 16.f, s) == .15625f;
+				return fequal(foldr(f, 16.f, s), .15625f);
 			})
 		),
 		std::make_tuple(

--- a/tests/set_tests.cpp
+++ b/tests/set_tests.cpp
@@ -126,7 +126,7 @@ test_set set_tests{
 				auto f = [](float x, float y){ return x/y; };
 
 
-				return foldr(f, 16.f, s) == .15625f;
+				return fequal(foldr(f, 16.f, s), .15625f);
 			})
 		),
 		std::make_tuple(


### PR DESCRIPTION
Some tests may not pass due to slight differences in floating
point numbers. They seem to pass when compiled with gcc on
some systems, but not all. It may relate to the gcc version.

$ gcc -v
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/lib/gcc/i686-linux-gnu/4.8/lto-wrapper
Target: i686-linux-gnu
Configured with: ../src/configure -v --with-pkgversion='Ubuntu 4.8.1-2ubuntu1~13.04' --with-bugurl=file:///usr/share/doc/gcc-4.8/README.Bugs --enable-languages=c,c++,java,go,d,fortran,objc,obj-c++ --prefix=/usr --program-suffix=-4.8 --enable-shared --enable-linker-build-id --libexecdir=/usr/lib --without-included-gettext --enable-threads=posix --with-gxx-include-dir=/usr/include/c++/4.8 --libdir=/usr/lib --enable-nls --with-sysroot=/ --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-gnu-unique-object --enable-plugin --with-system-zlib --disable-browser-plugin --enable-java-awt=gtk --enable-gtk-cairo --with-java-home=/usr/lib/jvm/java-1.5.0-gcj-4.8-i386/jre --enable-java-home --with-jvm-root-dir=/usr/lib/jvm/java-1.5.0-gcj-4.8-i386 --with-jvm-jar-dir=/usr/lib/jvm-exports/java-1.5.0-gcj-4.8-i386 --with-arch-directory=i386 --with-ecj-jar=/usr/share/java/eclipse-ecj.jar --enable-objc-gc --enable-targets=all --enable-multiarch --disable-werror --with-arch-32=i686 --with-multilib-list=m32,m64,mx32 --with-tune=generic --enable-checking=release --build=i686-linux-gnu --host=i686-linux-gnu --target=i686-linux-gnu
Thread model: posix
gcc version 4.8.1 (Ubuntu 4.8.1-2ubuntu1~13.04)

$ ./ftl_tests
Running test set 'prelude'...10/10 passed
Running test set 'either'...20/20 passed
Running test set 'either_trans'...18/18 passed
Running test set 'maybe'...29/29 passed
Running test set 'maybe_trans'...20/20 passed
Running test set 'future'...6/6 passed
Running test set 'lazy'...12/12 passed
Running test set 'lazy_trans'...6/6 passed
Running test set 'ord'...7/7 passed
Running test set 'functional'...
functor<function>::map: fail
functorstd::function::map: fail
9/11 passed
Running test set 'list'...24/24 passed
Running test set 'vector'...24/24 passed
Running test set 'forward_list'...22/22 passed
Running test set 'tuple'...5/5 passed
Running test set 'memory'...16/16 passed
Running test set 'string'...5/5 passed
Running test set 'set'...
foldable::foldr: fail
9/10 passed
Running test set 'map'...
foldable::foldr: fail
4/5 passed
Running test set 'unordered_map'...3/3 passed
Running test set 'concepts'...18/18 passed

This commit changes only the tests that failed. The other tests
likely succeed because their calculations can be exactly
represented in binary.
